### PR TITLE
[Don't merge] Prototype - simple

### DIFF
--- a/definitions/swagger.yaml
+++ b/definitions/swagger.yaml
@@ -301,14 +301,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  meta:
-                    $ref: '#/components/schemas/paginate_meta'
-                  servers:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/server'
+                $ref: '#/components/schemas/get_servers_result'
         '400':
           $ref: '#/components/responses/generic_400'
         '401':
@@ -1682,6 +1675,15 @@ components:
           description: タグの色
           example: ffffff
           nullable: true
+    get_servers_result:
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/paginate_meta'
+        servers:
+          type: array
+          items:
+            $ref: '#/components/schemas/server'
     server:
       type: object
       properties:

--- a/design/prototype/client.go
+++ b/design/prototype/client.go
@@ -1,0 +1,48 @@
+// Copyright 2021 The libphy authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prototype
+
+import "github.com/sacloud/libphy/openapi"
+
+const defaultAPIRootURL = "https://secure.sakura.ad.jp/cloud/api/dedicated-phy/1.0"
+
+type Client struct {
+	APIRootURL string
+
+	AccessToken       string
+	AccessTokenSecret string
+
+	// TODO その他オプション類をここに追加
+}
+
+func (c *Client) serverURL() string {
+	if c.APIRootURL != "" {
+		return c.APIRootURL
+	}
+	return defaultAPIRootURL
+}
+
+func (c *Client) apiClient() (openapi.ClientWithResponsesInterface, error) {
+	return openapi.NewClientWithResponses(
+		c.serverURL(),
+		func(client *openapi.Client) error {
+			client.RequestEditors = []openapi.RequestEditorFn{
+				openapi.PhyAuthInterceptor(c.AccessToken, c.AccessTokenSecret),
+				openapi.PhyRequestInterceptor(),
+			}
+			return nil
+		},
+	)
+}

--- a/design/prototype/server.go
+++ b/design/prototype/server.go
@@ -1,0 +1,46 @@
+// Copyright 2021 The libphy authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prototype
+
+import (
+	"context"
+
+	"github.com/sacloud/libphy/openapi"
+)
+
+type ServerAPI interface {
+	List(ctx context.Context, params *openapi.GetServersParams) (*openapi.GetServersResult, error)
+}
+
+func NewServerAPI(client *Client) ServerAPI {
+	return &ServerOp{Client: client}
+}
+
+type ServerOp struct {
+	Client *Client
+}
+
+func (op *ServerOp) List(ctx context.Context, params *openapi.GetServersParams) (*openapi.GetServersResult, error) {
+	client, err := op.Client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.GetServersWithResponse(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return response.Result()
+}

--- a/design/prototype/server_test.go
+++ b/design/prototype/server_test.go
@@ -12,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package openapi
+package prototype
 
 import (
 	"context"
 	"os"
 	"testing"
+
+	"github.com/sacloud/libphy/openapi"
 )
 
-func TestDummy(t *testing.T) {
+func TestServerOp_List(t *testing.T) {
 	if os.Getenv("TESTACC") == "" {
 		t.Skip("required: environment variable 'TESTACC'")
 	}
@@ -31,21 +33,12 @@ func TestDummy(t *testing.T) {
 		t.Skip("required: environment variable 'SAKURACLOUD_ACCESS_TOKEN' and 'SAKURACLOUD_ACCESS_TOKEN_SECRET'")
 	}
 
-	client, err := NewClientWithResponses("https://secure.sakura.ad.jp/cloud/api/dedicated-phy/1.0", func(c *Client) error {
-		c.RequestEditors = []RequestEditorFn{
-			PhyAuthInterceptor(token, secret),
-			PhyRequestInterceptor(),
-		}
-		return nil
-	})
+	client := &Client{AccessToken: token, AccessTokenSecret: secret}
+	serverOp := NewServerAPI(client)
+
+	results, err := serverOp.List(context.Background(), &openapi.GetServersParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	servers, err := client.GetServersWithResponse(context.Background(), &GetServersParams{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Log(string(servers.Body))
+	t.Log(results)
 }

--- a/openapi/errors.go
+++ b/openapi/errors.go
@@ -1,0 +1,41 @@
+// Copyright 2021 The libphy authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openapi
+
+import "fmt"
+
+func (e ProblemDetails400) Error() string {
+	return fmt.Sprintf("status: %d, title: %v, detail: %v", e.Status, e.Title, e.Detail)
+}
+
+func (e ProblemDetails401) Error() string {
+	return fmt.Sprintf("status: %d, code: %v, msg: %v", e.Status, e.ErrorCode, e.ErrorMsg)
+}
+
+func (e ProblemDetails404) Error() string {
+	return fmt.Sprintf("status: %d, title: %v, detail: %v", e.Status, e.Title, e.Detail)
+}
+
+func (e ProblemDetails409) Error() string {
+	return fmt.Sprintf("status: %d, title: %v, detail: %v", e.Status, e.Title, e.Detail)
+}
+
+func (e ProblemDetails429) Error() string {
+	return fmt.Sprintf("status: %d, title: %v, detail: %v", e.Status, e.Title, e.Detail)
+}
+
+func (e ProblemDetails503) Error() string {
+	return fmt.Sprintf("status: %d, title: %v, detail: %v", e.Status, e.Title, e.Detail)
+}

--- a/openapi/functions.go
+++ b/openapi/functions.go
@@ -1,0 +1,26 @@
+// Copyright 2021 The libphy authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openapi
+
+import "reflect"
+
+func eCoalesce(errs ...error) error {
+	for _, e := range errs {
+		if !(e == nil || reflect.ValueOf(e).IsNil()) {
+			return e
+		}
+	}
+	return nil
+}

--- a/openapi/get_servers_response.go
+++ b/openapi/get_servers_response.go
@@ -1,0 +1,19 @@
+// Copyright 2021 The libphy authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openapi
+
+func (r GetServersResponse) Result() (*GetServersResult, error) {
+	return r.JSON200, eCoalesce(r.JSON400, r.JSON401, r.JSON404, r.JSON429)
+}

--- a/openapi/interceptors.go
+++ b/openapi/interceptors.go
@@ -1,0 +1,40 @@
+// Copyright 2021 The libphy authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openapi
+
+import (
+	"context"
+	"net/http"
+)
+
+// PhyAuthInterceptor PHYへのリクエストに認証情報の注入を行う
+func PhyAuthInterceptor(token, secret string) func(context.Context, *http.Request) error {
+	return func(ctx context.Context, req *http.Request) error {
+		req.SetBasicAuth(token, secret)
+		return nil
+	}
+}
+
+// PhyRequestInterceptor PHYへのリクエストに必要なヘッダ類の注入を行う
+func PhyRequestInterceptor() func(context.Context, *http.Request) error {
+	return func(ctx context.Context, req *http.Request) error {
+		// https://manual.sakura.ad.jp/ds/phy/api/api-spec.html#section/基本的な使い方/入力パラメーター
+		// > GET 以外のメソッドでは、CSRFの対策として、ヘッダーに X-Requested-With: XMLHttpRequest を指定します。
+		if req.Method != http.MethodGet {
+			req.Header.Add("X-Requested-With", "XMLHttpRequest")
+		}
+		return nil
+	}
+}

--- a/openapi/zz_client_gen.go
+++ b/openapi/zz_client_gen.go
@@ -2135,14 +2135,11 @@ func (r GetPrivateNetworksPrivateNetworkIdResponse) StatusCode() int {
 type GetServersResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *struct {
-		Meta    *PaginateMeta `json:"meta,omitempty"`
-		Servers *[]Server     `json:"servers,omitempty"`
-	}
-	JSON400 *ProblemDetails400
-	JSON401 *ProblemDetails401
-	JSON404 *ProblemDetails404
-	JSON429 *ProblemDetails429
+	JSON200      *GetServersResult
+	JSON400      *ProblemDetails400
+	JSON401      *ProblemDetails401
+	JSON404      *ProblemDetails404
+	JSON429      *ProblemDetails429
 }
 
 // Status returns HTTPResponse.Status
@@ -3116,10 +3113,7 @@ func ParseGetServersResponse(rsp *http.Response) (*GetServersResponse, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			Meta    *PaginateMeta `json:"meta,omitempty"`
-			Servers *[]Server     `json:"servers,omitempty"`
-		}
+		var dest GetServersResult
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/openapi/zz_types_gen.go
+++ b/openapi/zz_types_gen.go
@@ -346,6 +346,12 @@ type DedicatedSubnetConfigStatus string
 // * `gateway_real` - ゲートウェイ機器実機
 type DedicatedSubnetIpv6SpecialUseAddressesType string
 
+// GetServersResult defines model for get_servers_result.
+type GetServersResult struct {
+	Meta    *PaginateMeta `json:"meta,omitempty"`
+	Servers *[]Server     `json:"servers,omitempty"`
+}
+
 // ネットワークインターフェースの接続ポート情報
 type InterfacePort struct {
 	// ポート有効状態(通信が有効になっている場合 `true`)


### PR DESCRIPTION
設計/実装の検討のためのプロトタイプ実装
API定義から生成されたコードをラップするコードを手作業で実装する方式。

### メリット

- シンプル
- 手作業なため(コード生成などと比べると)柔軟に実装できる

### デメリット

- 上流のAPI定義が更新された場合に
  - 作業が多め
  - 影響箇所の特定に難あり

## その他気づいた点など

`GET /servers/`での正常系レスポンス(200)などのようにパス定義の中にスキーマ定義が埋め込まれたケースがまだあるが、
手作業でラップする際は埋め込まれたスキーマを直接参照したいケースが多そう。

例: `GET /servers/`の正常系レスポンス(As-Is)

https://github.com/sacloud/libphy/blob/acc6922ffb7addd9e0c772d033be13e2da982068/openapi/zz_client_gen.go#L2135-L2146

ラップする際は`JSON200`が指す型だけ欲しい(以下の`openapi.GetServersResult`みたいな)が型が埋め込みされている

```go
type ServerAPI interface {
	List(ctx context.Context, params *openapi.GetServersParams) (*openapi.GetServersResult, error)
}
```

このプロトタイプでは定義ファイルを修正し埋め込まれたスキーマを切り出して対応している。