### PR TITLE
spec: set name to request parameters

### DIFF
--- a/fake/server/servers.go
+++ b/fake/server/servers.go
@@ -57,7 +57,7 @@ func (s *Server) ListOSImages(c *gin.Context, serverId openapi.ServerId) {
 // OSInstall OSインストールの実行
 // (POST /servers/{server_id}/os_install/)
 func (s *Server) OSInstall(c *gin.Context, serverId openapi.ServerId, _ openapi.OSInstallParams) {
-	var paramJSON openapi.OSInstallJSONBody
+	var paramJSON openapi.OsInstallParameter
 	if err := c.ShouldBindJSON(&paramJSON); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -84,7 +84,7 @@ func (s *Server) ReadServerPortChannel(c *gin.Context, serverId openapi.ServerId
 // ServerConfigureBonding ポートチャネル ボンディング設定
 // (POST /servers/{server_id}/port_channels/{port_channel_id}/configure_bonding/)
 func (s *Server) ServerConfigureBonding(c *gin.Context, serverId openapi.ServerId, portChannelId openapi.PortChannelId, _ openapi.ServerConfigureBondingParams) {
-	var paramJSON openapi.ServerConfigureBondingJSONBody
+	var paramJSON openapi.ConfigureBondingParameter
 	if err := c.ShouldBindJSON(&paramJSON); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -112,7 +112,7 @@ func (s *Server) ReadServerPort(c *gin.Context, serverId openapi.ServerId, portI
 // UpdateServerPort ポート名称設定
 // (PATCH /servers/{server_id}/ports/{port_id}/)
 func (s *Server) UpdateServerPort(c *gin.Context, serverId openapi.ServerId, portId openapi.PortId, _ openapi.UpdateServerPortParams) {
-	var paramJSON openapi.UpdateServerPortJSONBody
+	var paramJSON openapi.UpdateServerPortParameter
 	if err := c.ShouldBindJSON(&paramJSON); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -129,7 +129,7 @@ func (s *Server) UpdateServerPort(c *gin.Context, serverId openapi.ServerId, por
 // ServerAssignNetwork ネットワーク接続設定の変更
 // (POST /servers/{server_id}/ports/{port_id}/assign_network/)
 func (s *Server) ServerAssignNetwork(c *gin.Context, serverId openapi.ServerId, portId openapi.PortId, _ openapi.ServerAssignNetworkParams) {
-	var paramJSON openapi.ServerAssignNetworkJSONBody
+	var paramJSON openapi.AssignNetworkParameter
 	if err := c.ShouldBindJSON(&paramJSON); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -146,7 +146,7 @@ func (s *Server) ServerAssignNetwork(c *gin.Context, serverId openapi.ServerId, 
 // EnableServerPort ポート有効/無効設定
 // (POST /servers/{server_id}/ports/{port_id}/enable/)
 func (s *Server) EnableServerPort(c *gin.Context, serverId openapi.ServerId, portId openapi.PortId, _ openapi.EnableServerPortParams) {
-	var paramJSON openapi.EnableServerPortJSONBody
+	var paramJSON openapi.EnableServerPortParameter
 	if err := c.ShouldBindJSON(&paramJSON); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -174,7 +174,7 @@ func (s *Server) ReadServerTrafficByPort(c *gin.Context, serverId openapi.Server
 // ServerPowerControl サーバーの電源操作
 // (POST /servers/{server_id}/power_control/)
 func (s *Server) ServerPowerControl(c *gin.Context, serverId openapi.ServerId, _ openapi.ServerPowerControlParams) {
-	var paramJSON openapi.ServerPowerControlJSONBody
+	var paramJSON openapi.PowerControlParameter
 	if err := c.ShouldBindJSON(&paramJSON); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/fake/server/services.go
+++ b/fake/server/services.go
@@ -46,7 +46,7 @@ func (s *Server) ReadService(c *gin.Context, serviceId openapi.ServiceId) {
 // UpdateService サービスの名称・説明の変更
 // (PATCH /services/{service_id}/)
 func (s *Server) UpdateService(c *gin.Context, serviceId openapi.ServiceId, _ openapi.UpdateServiceParams) {
-	var paramJSON openapi.UpdateServiceJSONBody
+	var paramJSON openapi.UpdateServiceParameter
 	if err := c.ShouldBindJSON(&paramJSON); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/fake/servers_test.go
+++ b/fake/servers_test.go
@@ -329,7 +329,7 @@ func TestDataStore_Servers(t *testing.T) {
 	})
 
 	t.Run("os install", func(t *testing.T) {
-		err := ds.OSInstall("100000000002", openapi.OSInstallJSONBody{
+		err := ds.OSInstall("100000000002", openapi.OsInstallParameter{
 			ManualPartition: true,
 			OsImageId:       "usacloud2",
 			Password:        "passw0rd",
@@ -350,7 +350,7 @@ func TestDataStore_Servers(t *testing.T) {
 	})
 
 	t.Run("update server port", func(t *testing.T) {
-		_, err := ds.UpdateServerPort("100000000002", 2002, openapi.UpdateServerPortJSONBody{
+		_, err := ds.UpdateServerPort("100000000002", 2002, openapi.UpdateServerPortParameter{
 			Nickname: "server02-port01-upd",
 		})
 		require.NoError(t, err)
@@ -365,7 +365,7 @@ func TestDataStore_Servers(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, before.Enabled)
 
-		_, err = ds.EnableServerPort("100000000002", 2002, openapi.EnableServerPortJSONBody{Enable: true})
+		_, err = ds.EnableServerPort("100000000002", 2002, openapi.EnableServerPortParameter{Enable: true})
 		require.NoError(t, err)
 
 		after, err := ds.ReadServerPort("100000000002", 2002)
@@ -375,10 +375,10 @@ func TestDataStore_Servers(t *testing.T) {
 
 	t.Run("assign network", func(t *testing.T) {
 		t.Run("to common global", func(t *testing.T) {
-			internetType := openapi.AssignNetworkInternetTypeCommonSubnet
-			_, err := ds.ServerAssignNetwork("100000000002", 2002, openapi.ServerAssignNetworkJSONBody{
+			internetType := openapi.AssignNetworkParameterInternetTypeCommonSubnet
+			_, err := ds.ServerAssignNetwork("100000000002", 2002, openapi.AssignNetworkParameter{
 				InternetType: &internetType,
-				Mode:         openapi.AssignNetworkModeAccess,
+				Mode:         openapi.AssignNetworkParameterModeAccess,
 			})
 			require.NoError(t, err)
 
@@ -389,11 +389,11 @@ func TestDataStore_Servers(t *testing.T) {
 		})
 
 		t.Run("to dedicated subnet", func(t *testing.T) {
-			internetType := openapi.AssignNetworkInternetTypeDedicatedSubnet
+			internetType := openapi.AssignNetworkParameterInternetTypeDedicatedSubnet
 			subnetId := "100000000001"
-			_, err := ds.ServerAssignNetwork("100000000002", 2002, openapi.ServerAssignNetworkJSONBody{
+			_, err := ds.ServerAssignNetwork("100000000002", 2002, openapi.AssignNetworkParameter{
 				InternetType:      &internetType,
-				Mode:              openapi.AssignNetworkModeAccess,
+				Mode:              openapi.AssignNetworkParameterModeAccess,
 				DedicatedSubnetId: &subnetId,
 			})
 			require.NoError(t, err)
@@ -406,8 +406,8 @@ func TestDataStore_Servers(t *testing.T) {
 
 		t.Run("to private subnet", func(t *testing.T) {
 			privateNetworkIds := []string{"100000000001"}
-			_, err := ds.ServerAssignNetwork("100000000002", 2002, openapi.ServerAssignNetworkJSONBody{
-				Mode:              openapi.AssignNetworkModeAccess,
+			_, err := ds.ServerAssignNetwork("100000000002", 2002, openapi.AssignNetworkParameter{
+				Mode:              openapi.AssignNetworkParameterModeAccess,
 				PrivateNetworkIds: &privateNetworkIds,
 			})
 			require.NoError(t, err)
@@ -420,11 +420,11 @@ func TestDataStore_Servers(t *testing.T) {
 		})
 
 		t.Run("trunk port", func(t *testing.T) {
-			internetType := openapi.AssignNetworkInternetTypeCommonSubnet
+			internetType := openapi.AssignNetworkParameterInternetTypeCommonSubnet
 			privateNetworkIds := []string{"100000000001"}
-			_, err := ds.ServerAssignNetwork("100000000002", 2002, openapi.ServerAssignNetworkJSONBody{
+			_, err := ds.ServerAssignNetwork("100000000002", 2002, openapi.AssignNetworkParameter{
 				InternetType:      &internetType,
-				Mode:              openapi.AssignNetworkModeTrunk,
+				Mode:              openapi.AssignNetworkParameterModeTrunk,
 				PrivateNetworkIds: &privateNetworkIds,
 			})
 			require.NoError(t, err)
@@ -437,8 +437,8 @@ func TestDataStore_Servers(t *testing.T) {
 		})
 
 		t.Run("disconnect", func(t *testing.T) {
-			_, err := ds.ServerAssignNetwork("100000000002", 2002, openapi.ServerAssignNetworkJSONBody{
-				Mode: openapi.AssignNetworkModeAccess,
+			_, err := ds.ServerAssignNetwork("100000000002", 2002, openapi.AssignNetworkParameter{
+				Mode: openapi.AssignNetworkParameterModeAccess,
 			})
 			require.NoError(t, err)
 
@@ -451,7 +451,7 @@ func TestDataStore_Servers(t *testing.T) {
 	})
 
 	t.Run("power control", func(t *testing.T) {
-		err := ds.ServerPowerControl("100000000002", openapi.ServerPowerControlJSONBody{Operation: "reset"})
+		err := ds.ServerPowerControl("100000000002", openapi.PowerControlParameter{Operation: "reset"})
 		require.NoError(t, err)
 		time.Sleep(ds.actionInterval() * 10) // 反映されるまで少し待つ
 
@@ -459,7 +459,7 @@ func TestDataStore_Servers(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, openapi.ServerPowerStatusStatusOn, powerStatus.Status)
 
-		err = ds.ServerPowerControl("100000000002", openapi.ServerPowerControlJSONBody{Operation: "off"})
+		err = ds.ServerPowerControl("100000000002", openapi.PowerControlParameter{Operation: "off"})
 		require.NoError(t, err)
 		time.Sleep(ds.actionInterval() * 10) // 反映されるまで少し待つ
 
@@ -478,7 +478,7 @@ func TestDataStore_Servers(t *testing.T) {
 	// 副作用(portIdが変わる)があるため最後に実施
 	t.Run("configure bonding", func(t *testing.T) {
 		t.Run("LACP", func(t *testing.T) {
-			pc, err := ds.ServerConfigureBonding("100000000002", 1002, openapi.ServerConfigureBondingJSONBody{
+			pc, err := ds.ServerConfigureBonding("100000000002", 1002, openapi.ConfigureBondingParameter{
 				BondingType:   openapi.BondingTypeLacp,
 				PortNicknames: nil,
 			})
@@ -489,7 +489,7 @@ func TestDataStore_Servers(t *testing.T) {
 			require.Len(t, server.Server.Ports, 1)
 		})
 		t.Run("Single", func(t *testing.T) {
-			pc, err := ds.ServerConfigureBonding("100000000002", 1002, openapi.ServerConfigureBondingJSONBody{
+			pc, err := ds.ServerConfigureBonding("100000000002", 1002, openapi.ConfigureBondingParameter{
 				BondingType:   openapi.BondingTypeSingle,
 				PortNicknames: nil,
 			})

--- a/fake/services.go
+++ b/fake/services.go
@@ -54,16 +54,12 @@ func (engine *Engine) ReadService(serviceId openapi.ServiceId) (*openapi.Service
 
 // UpdateService サービスの名称・説明の変更
 // (PATCH /services/{service_id}/)
-func (engine *Engine) UpdateService(serviceId openapi.ServiceId, body openapi.UpdateServiceJSONBody) (*openapi.Service, error) {
+func (engine *Engine) UpdateService(serviceId openapi.ServiceId, body openapi.UpdateServiceParameter) (*openapi.Service, error) {
 	defer engine.lock()()
 	service := engine.getServiceById(serviceId)
 	if service != nil {
-		if body.Nickname != nil {
-			service.Nickname = *body.Nickname
-		}
-		if body.Description != nil {
-			service.Description = body.Description
-		}
+		service.Nickname = body.Nickname
+		service.Description = body.Description
 		var svc openapi.Service
 		if err := deepcopy.Copy(&svc, service); err != nil {
 			return nil, err

--- a/fake/services_test.go
+++ b/fake/services_test.go
@@ -83,9 +83,9 @@ func TestDataStore_Services(t *testing.T) {
 	})
 
 	t.Run("update", func(t *testing.T) {
-		svc, err := ds.UpdateService("100000000001", openapi.UpdateServiceJSONBody{
+		svc, err := ds.UpdateService("100000000001", openapi.UpdateServiceParameter{
 			Description: nil,
-			Nickname:    pointer.String("nickname1-upd"),
+			Nickname:    "nickname1-upd",
 		})
 		require.NoError(t, err)
 		require.NotNil(t, svc)

--- a/openapi/spec/swagger.yaml
+++ b/openapi/spec/swagger.yaml
@@ -186,20 +186,7 @@ paths:
         content:
           application/json:
             schema:
-              properties:
-                nickname:
-                  type: string
-                  example: サーバーやネットワークの簡潔な名前
-                  description: 名称：サーバーやネットワークなどの表示名
-                  maxLength: 64
-                description:
-                  type: string
-                  example: |-
-                    サーバーやネットワークの利用用途などを
-                    自由に記述
-                  description: メモ：サーバーやネットワークなどの説明
-                  nullable: true
-                  maxLength: 1000
+              $ref: '#/components/schemas/update_service_parameter'
       responses:
         '200':
           description: 成功
@@ -439,22 +426,7 @@ paths:
         content:
           application/json:
             schema:
-              required:
-                - os_image_id
-                - password
-                - manual_partition
-              properties:
-                password:
-                  $ref: '#/components/schemas/password_input'
-                os_image_id:
-                  type: string
-                  description: インストールするOSイメージ名
-                  example: centos7-x86_64
-                manual_partition:
-                  type: boolean
-                  description: |-
-                    リモートコンソールを利用し手動パーティション指定を行う
-                    (OSが対応している場合のみ)
+              $ref: '#/components/schemas/os_install_parameter'
       responses:
         '204':
           description: 処理開始
@@ -526,12 +498,8 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - operation
-              properties:
-                operation:
-                  $ref: '#/components/schemas/server_power_operations'
+              $ref: '#/components/schemas/power_control_parameter'
+
       responses:
         '204':
           description: 成功
@@ -615,30 +583,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - port_channel_id
-                - bonding_type
-              properties:
-                bonding_type:
-                  $ref: '#/components/schemas/bonding_type'
-                port_nicknames:
-                  type: array
-                  nullable: true
-                  default: null
-                  description: |-
-                    作成するポート名称の指定
-
-                    * `null`の場合は自動設定
-                    * ボンディング構成する場合は1要素の配列
-                    * ボンディングなしの場合は2要素の配列
-                  items:
-                    type: string
-                    description: ポート名称
-                    maxLength: 50
-                  example:
-                    - ポート名称1
-                    - ポート名称2
+              $ref: '#/components/schemas/configure_bonding_parameter'
       responses:
         '200':
           description: 成功
@@ -726,15 +671,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - nickname
-              properties:
-                nickname:
-                  type: string
-                  description: ポート名称
-                  example: ポート名称1
-                  maxLength: 50
+              $ref: '#/components/schemas/update_server_port_parameter'
       responses:
         '200':
           description: 成功
@@ -828,13 +765,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - enable
-              properties:
-                enable:
-                  type: boolean
-                  description: 通信を有効にする場合に `true`
+              $ref: '#/components/schemas/enable_server_port_parameter'
       responses:
         '200':
           description: 成功
@@ -879,7 +810,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/assign_network'
+              $ref: '#/components/schemas/assign_network_parameter'
       responses:
         '200':
           description: 成功
@@ -1194,6 +1125,152 @@ components:
         type: integer
       description: ポートID
   schemas:
+    # request parameter
+    os_install_parameter:
+      required:
+        - os_image_id
+        - password
+        - manual_partition
+      properties:
+        password:
+          $ref: '#/components/schemas/password_input'
+        os_image_id:
+          type: string
+          description: インストールするOSイメージ名
+          example: centos7-x86_64
+        manual_partition:
+          type: boolean
+          description: |-
+            リモートコンソールを利用し手動パーティション指定を行う
+            (OSが対応している場合のみ)
+
+    update_service_parameter:
+      properties:
+        nickname:
+          type: string
+          example: サーバーやネットワークの簡潔な名前
+          description: 名称：サーバーやネットワークなどの表示名
+          maxLength: 64
+        description:
+          type: string
+          example: |-
+            サーバーやネットワークの利用用途などを
+            自由に記述
+          description: メモ：サーバーやネットワークなどの説明
+          nullable: true
+          maxLength: 1000
+      required:
+        - nickname
+        - description
+    power_control_parameter:
+      type: object
+      properties:
+        operation:
+          $ref: '#/components/schemas/server_power_operations'
+      required:
+        - operation
+    configure_bonding_parameter:
+      type: object
+      properties:
+        bonding_type:
+          $ref: '#/components/schemas/bonding_type'
+        port_nicknames:
+          type: array
+          nullable: true
+          default: null
+          description: |-
+            作成するポート名称の指定
+
+            * `null`の場合は自動設定
+            * ボンディング構成する場合は1要素の配列
+            * ボンディングなしの場合は2要素の配列
+          items:
+            type: string
+            description: ポート名称
+            maxLength: 50
+          example:
+            - ポート名称1
+            - ポート名称2
+      required:
+        - port_channel_id
+        - bonding_type
+    update_server_port_parameter:
+      type: object
+      properties:
+        nickname:
+          type: string
+          description: ポート名称
+          example: ポート名称1
+          maxLength: 50
+      required:
+        - nickname
+    enable_server_port_parameter:
+      type: object
+      properties:
+        enable:
+          type: boolean
+          description: 通信を有効にする場合に `true`
+      required:
+        - enable
+    assign_network_parameter:
+      type: object
+      description: |-
+        ポートの接続ネットワーク指定
+
+        `mode=access`の場合は
+
+        * 共用グローバルネットワーク
+        * 専用グローバルネットワーク
+        * ローカルネットワーク
+
+        のいずれか1つのみ接続可能で、
+        複数のネットワークが指定されている場合はエラーとなる
+      required:
+        - mode
+        - internet_type
+        - dedicated_subnet_id
+        - private_network_ids
+      properties:
+        mode:
+          type: string
+          enum:
+            - access
+            - trunk
+          description: |-
+            ポートモード
+
+            * `access` - アクセスポート
+            * `trunk` - トランクポート
+        internet_type:
+          type: string
+          nullable: true
+          default: null
+          enum:
+            - common_subnet
+            - dedicated_subnet
+          description: |-
+            * `null` - インターネット接続なし
+            * `common_subnet` - 共用グローバルネットワーク利用
+            * `dedicated_subnet` - 専用グローバルネットワーク利用
+          example: dedicated_subnet
+        dedicated_subnet_id:
+          type: string
+          nullable: true
+          default: null
+          description: |-
+            専用グローバルネットワークのサービスコード指定
+            `global_network_type`が`dedicated_subnet`の場合に必須
+          example: '345678901234'
+        private_network_ids:
+          type: array
+          nullable: true
+          default: null
+          description: 接続先ローカルネットワークの配列
+          items:
+            type: string
+            description: 接続先ローカルネットワークのサービスコード
+            example: '234567890123'
+
     # services
     services:
       type: object
@@ -1899,65 +1976,6 @@ components:
       required:
         - timestamp
         - value
-    assign_network:
-      type: object
-      description: |-
-        ポートの接続ネットワーク指定
-
-        `mode=access`の場合は
-
-        * 共用グローバルネットワーク
-        * 専用グローバルネットワーク
-        * ローカルネットワーク
-
-        のいずれか1つのみ接続可能で、
-        複数のネットワークが指定されている場合はエラーとなる
-      required:
-        - mode
-        - internet_type
-        - dedicated_subnet_id
-        - private_network_ids
-      properties:
-        mode:
-          type: string
-          enum:
-            - access
-            - trunk
-          description: |-
-            ポートモード
-
-            * `access` - アクセスポート
-            * `trunk` - トランクポート
-        internet_type:
-          type: string
-          nullable: true
-          default: null
-          enum:
-            - common_subnet
-            - dedicated_subnet
-          description: |-
-            * `null` - インターネット接続なし
-            * `common_subnet` - 共用グローバルネットワーク利用
-            * `dedicated_subnet` - 専用グローバルネットワーク利用
-          example: dedicated_subnet
-        dedicated_subnet_id:
-          type: string
-          nullable: true
-          default: null
-          description: |-
-            専用グローバルネットワークのサービスコード指定
-            `global_network_type`が`dedicated_subnet`の場合に必須
-          example: '345678901234'
-        private_network_ids:
-          type: array
-          nullable: true
-          default: null
-          description: 接続先ローカルネットワークの配列
-          items:
-            type: string
-            description: 接続先ローカルネットワークのサービスコード
-            example: '234567890123'
-
     bonding_type:
       type: string
       enum:
@@ -1970,6 +1988,7 @@ components:
         * `lacp` - LACP
         * `static` - static link aggregation
         * `single` - ボンディングなし(単体構成)
+
 
     # dedicated subnets
     dedicated_subnets:
@@ -2333,6 +2352,7 @@ components:
         * `soft` - ACPIシャットダウン(OSでの電源シャットダウン)
         * `reset` - ハードウェア電源リセット(電源OFF+電源ON)
         * `off` - ハードウェア電源OFF
+
 
 
     # errors

--- a/openapi/zz_types_gen.go
+++ b/openapi/zz_types_gen.go
@@ -27,18 +27,18 @@ const (
 	Account_api_keyScopes = "account_api_key.Scopes"
 )
 
-// Defines values for AssignNetworkInternetType.
+// Defines values for AssignNetworkParameterInternetType.
 const (
-	AssignNetworkInternetTypeCommonSubnet AssignNetworkInternetType = "common_subnet"
+	AssignNetworkParameterInternetTypeCommonSubnet AssignNetworkParameterInternetType = "common_subnet"
 
-	AssignNetworkInternetTypeDedicatedSubnet AssignNetworkInternetType = "dedicated_subnet"
+	AssignNetworkParameterInternetTypeDedicatedSubnet AssignNetworkParameterInternetType = "dedicated_subnet"
 )
 
-// Defines values for AssignNetworkMode.
+// Defines values for AssignNetworkParameterMode.
 const (
-	AssignNetworkModeAccess AssignNetworkMode = "access"
+	AssignNetworkParameterModeAccess AssignNetworkParameterMode = "access"
 
-	AssignNetworkModeTrunk AssignNetworkMode = "trunk"
+	AssignNetworkParameterModeTrunk AssignNetworkParameterMode = "trunk"
 )
 
 // Defines values for BondingType.
@@ -275,7 +275,7 @@ const (
 //
 // のいずれか1つのみ接続可能で、
 // 複数のネットワークが指定されている場合はエラーとなる
-type AssignNetwork struct {
+type AssignNetworkParameter struct {
 	// 専用グローバルネットワークのサービスコード指定
 	// `global_network_type`が`dedicated_subnet`の場合に必須
 	DedicatedSubnetId *string `json:"dedicated_subnet_id"`
@@ -283,13 +283,13 @@ type AssignNetwork struct {
 	// * `null` - インターネット接続なし
 	// * `common_subnet` - 共用グローバルネットワーク利用
 	// * `dedicated_subnet` - 専用グローバルネットワーク利用
-	InternetType *AssignNetworkInternetType `json:"internet_type"`
+	InternetType *AssignNetworkParameterInternetType `json:"internet_type"`
 
 	// ポートモード
 	//
 	// * `access` - アクセスポート
 	// * `trunk` - トランクポート
-	Mode AssignNetworkMode `json:"mode"`
+	Mode AssignNetworkParameterMode `json:"mode"`
 
 	// 接続先ローカルネットワークの配列
 	PrivateNetworkIds *[]string `json:"private_network_ids"`
@@ -298,13 +298,13 @@ type AssignNetwork struct {
 // * `null` - インターネット接続なし
 // * `common_subnet` - 共用グローバルネットワーク利用
 // * `dedicated_subnet` - 専用グローバルネットワーク利用
-type AssignNetworkInternetType string
+type AssignNetworkParameterInternetType string
 
 // ポートモード
 //
 // * `access` - アクセスポート
 // * `trunk` - トランクポート
-type AssignNetworkMode string
+type AssignNetworkParameterMode string
 
 // 専用グローバルネットワーク情報(共用グローバルネットワーク割り当て時は`null`)
 type AttachedDedicatedSubnet struct {
@@ -361,6 +361,23 @@ type CachedPowerStatus struct {
 // 電源状態
 type CachedPowerStatusStatus string
 
+// ConfigureBondingParameter defines model for configure_bonding_parameter.
+type ConfigureBondingParameter struct {
+	// ボンディング方式
+	//
+	// * `lacp` - LACP
+	// * `static` - static link aggregation
+	// * `single` - ボンディングなし(単体構成)
+	BondingType BondingType `json:"bonding_type"`
+
+	// 作成するポート名称の指定
+	//
+	// * `null`の場合は自動設定
+	// * ボンディング構成する場合は1要素の配列
+	// * ボンディングなしの場合は2要素の配列
+	PortNicknames *[]string `json:"port_nicknames"`
+}
+
 // DedicatedSubnet defines model for dedicated_subnet.
 type DedicatedSubnet struct {
 	// 設定変更によるロック状態
@@ -406,6 +423,12 @@ type DedicatedSubnetConfigStatus string
 type DedicatedSubnets struct {
 	DedicatedSubnets []DedicatedSubnet `json:"dedicated_subnets"`
 	Meta             PaginateMeta      `json:"meta"`
+}
+
+// EnableServerPortParameter defines model for enable_server_port_parameter.
+type EnableServerPortParameter struct {
+	// 通信を有効にする場合に `true`
+	Enable bool `json:"enable"`
 }
 
 // HybridConnection defines model for hybrid_connection.
@@ -619,6 +642,20 @@ type OsImage struct {
 	SuperuserName string `json:"superuser_name"`
 }
 
+// OsInstallParameter defines model for os_install_parameter.
+type OsInstallParameter struct {
+	// リモートコンソールを利用し手動パーティション指定を行う
+	// (OSが対応している場合のみ)
+	ManualPartition bool `json:"manual_partition"`
+
+	// インストールするOSイメージ名
+	OsImageId string `json:"os_image_id"`
+
+	// 英数字と記号の組み合わせ
+	// 1文字以上のアルファベットと1文字以上の数字が必須
+	Password PasswordInput `json:"password"`
+}
+
 // PaginateMeta defines model for paginate_meta.
 type PaginateMeta struct {
 	// 総件数
@@ -659,6 +696,17 @@ type PortChannel struct {
 // * `1gbe` - 1GbE
 // * `10gbe` - 10GbE
 type PortChannelLinkSpeedType string
+
+// PowerControlParameter defines model for power_control_parameter.
+type PowerControlParameter struct {
+	// 操作内容
+	//
+	// * `on` - 電源ON
+	// * `soft` - ACPIシャットダウン(OSでの電源シャットダウン)
+	// * `reset` - ハードウェア電源リセット(電源OFF+電源ON)
+	// * `off` - ハードウェア電源OFF
+	Operation ServerPowerOperations `json:"operation"`
+}
 
 // PrivateNetwork defines model for private_network.
 type PrivateNetwork struct {
@@ -1174,6 +1222,21 @@ type TrafficGraphData struct {
 	Value int `json:"value"`
 }
 
+// UpdateServerPortParameter defines model for update_server_port_parameter.
+type UpdateServerPortParameter struct {
+	// ポート名称
+	Nickname string `json:"nickname"`
+}
+
+// UpdateServiceParameter defines model for update_service_parameter.
+type UpdateServiceParameter struct {
+	// メモ：サーバーやネットワークなどの説明
+	Description *string `json:"description"`
+
+	// 名称：サーバーやネットワークなどの表示名
+	Nickname string `json:"nickname"`
+}
+
 // Zone defines model for zone.
 type Zone struct {
 	// 地域名
@@ -1352,18 +1415,7 @@ type ListServersParamsPowerStatus string
 type ListServersParamsOrdering string
 
 // OSInstallJSONBody defines parameters for OSInstall.
-type OSInstallJSONBody struct {
-	// リモートコンソールを利用し手動パーティション指定を行う
-	// (OSが対応している場合のみ)
-	ManualPartition bool `json:"manual_partition"`
-
-	// インストールするOSイメージ名
-	OsImageId string `json:"os_image_id"`
-
-	// 英数字と記号の組み合わせ
-	// 1文字以上のアルファベットと1文字以上の数字が必須
-	Password PasswordInput `json:"password"`
-}
+type OSInstallJSONBody OsInstallParameter
 
 // OSInstallParams defines parameters for OSInstall.
 type OSInstallParams struct {
@@ -1375,21 +1427,7 @@ type OSInstallParams struct {
 type OSInstallParamsXRequestedWith string
 
 // ServerConfigureBondingJSONBody defines parameters for ServerConfigureBonding.
-type ServerConfigureBondingJSONBody struct {
-	// ボンディング方式
-	//
-	// * `lacp` - LACP
-	// * `static` - static link aggregation
-	// * `single` - ボンディングなし(単体構成)
-	BondingType BondingType `json:"bonding_type"`
-
-	// 作成するポート名称の指定
-	//
-	// * `null`の場合は自動設定
-	// * ボンディング構成する場合は1要素の配列
-	// * ボンディングなしの場合は2要素の配列
-	PortNicknames *[]string `json:"port_nicknames"`
-}
+type ServerConfigureBondingJSONBody ConfigureBondingParameter
 
 // ServerConfigureBondingParams defines parameters for ServerConfigureBonding.
 type ServerConfigureBondingParams struct {
@@ -1401,10 +1439,7 @@ type ServerConfigureBondingParams struct {
 type ServerConfigureBondingParamsXRequestedWith string
 
 // UpdateServerPortJSONBody defines parameters for UpdateServerPort.
-type UpdateServerPortJSONBody struct {
-	// ポート名称
-	Nickname string `json:"nickname"`
-}
+type UpdateServerPortJSONBody UpdateServerPortParameter
 
 // UpdateServerPortParams defines parameters for UpdateServerPort.
 type UpdateServerPortParams struct {
@@ -1416,7 +1451,7 @@ type UpdateServerPortParams struct {
 type UpdateServerPortParamsXRequestedWith string
 
 // ServerAssignNetworkJSONBody defines parameters for ServerAssignNetwork.
-type ServerAssignNetworkJSONBody AssignNetwork
+type ServerAssignNetworkJSONBody AssignNetworkParameter
 
 // ServerAssignNetworkParams defines parameters for ServerAssignNetwork.
 type ServerAssignNetworkParams struct {
@@ -1428,10 +1463,7 @@ type ServerAssignNetworkParams struct {
 type ServerAssignNetworkParamsXRequestedWith string
 
 // EnableServerPortJSONBody defines parameters for EnableServerPort.
-type EnableServerPortJSONBody struct {
-	// 通信を有効にする場合に `true`
-	Enable bool `json:"enable"`
-}
+type EnableServerPortJSONBody EnableServerPortParameter
 
 // EnableServerPortParams defines parameters for EnableServerPort.
 type EnableServerPortParams struct {
@@ -1458,15 +1490,7 @@ type ReadServerTrafficByPortParams struct {
 type ReadServerTrafficByPortParamsStep int
 
 // ServerPowerControlJSONBody defines parameters for ServerPowerControl.
-type ServerPowerControlJSONBody struct {
-	// 操作内容
-	//
-	// * `on` - 電源ON
-	// * `soft` - ACPIシャットダウン(OSでの電源シャットダウン)
-	// * `reset` - ハードウェア電源リセット(電源OFF+電源ON)
-	// * `off` - ハードウェア電源OFF
-	Operation ServerPowerOperations `json:"operation"`
-}
+type ServerPowerControlJSONBody PowerControlParameter
 
 // ServerPowerControlParams defines parameters for ServerPowerControl.
 type ServerPowerControlParams struct {
@@ -1523,13 +1547,7 @@ type ListServicesParamsProductCategory string
 type ListServicesParamsOrdering string
 
 // UpdateServiceJSONBody defines parameters for UpdateService.
-type UpdateServiceJSONBody struct {
-	// メモ：サーバーやネットワークなどの説明
-	Description *string `json:"description"`
-
-	// 名称：サーバーやネットワークなどの表示名
-	Nickname *string `json:"nickname,omitempty"`
-}
+type UpdateServiceJSONBody UpdateServiceParameter
 
 // UpdateServiceParams defines parameters for UpdateService.
 type UpdateServiceParams struct {


### PR DESCRIPTION
closes #43 

PATCH/POSTなどボディで受け取るJSONに対し`xxxParameter`という名前を付与。