### PR TITLE
Improve Examples

### DIFF
--- a/apis/v1/example_fake_test.go
+++ b/apis/v1/example_fake_test.go
@@ -1,0 +1,49 @@
+// Copyright 2021 The phy-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1_test
+
+import (
+	"net/http/httptest"
+	"time"
+
+	v1 "github.com/sacloud/phy-go/apis/v1"
+	"github.com/sacloud/phy-go/fake"
+	"github.com/sacloud/phy-go/fake/server"
+)
+
+func init() {
+	initFakeServer()
+}
+
+func initFakeServer() {
+	fakeServer := &server.Server{
+		Engine: &fake.Engine{
+			Services: []*v1.Service{
+				{
+					Activated: time.Now(),
+					Nickname:  "server01",
+					Plan: &v1.ServicePlan{
+						Name:   "plan01",
+						PlanId: "xxx",
+					},
+					ProductCategory: v1.ServiceProductCategoryServer,
+					ServiceId:       "100000000001",
+				},
+			},
+		},
+	}
+	sv := httptest.NewServer(fakeServer.Handler())
+	serverURL = sv.URL
+}

--- a/apis/v1/example_test.go
+++ b/apis/v1/example_test.go
@@ -12,40 +12,40 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1
+package v1_test
 
 import (
 	"context"
+	"fmt"
 	"os"
-	"testing"
+
+	v1 "github.com/sacloud/phy-go/apis/v1"
 )
 
-func TestDummy(t *testing.T) {
-	if os.Getenv("TESTACC") == "" {
-		t.Skip("required: environment variable 'TESTACC'")
-	}
+var serverURL = "https://secure.sakura.ad.jp/cloud/api/dedicated-phy/1.0"
 
+// Example API定義から生成されたコードを直接利用する例
+func Example() {
 	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
 	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
-	if token == "" || secret == "" {
-		t.Skip("required: environment variable 'SAKURACLOUD_ACCESS_TOKEN' and 'SAKURACLOUD_ACCESS_TOKEN_SECRET'")
-	}
 
-	client, err := NewClientWithResponses("https://secure.sakura.ad.jp/cloud/api/dedicated-phy/1.0", func(c *Client) error {
-		c.RequestEditors = []RequestEditorFn{
-			PhyAuthInterceptor(token, secret),
-			PhyRequestInterceptor(),
+	client, err := v1.NewClientWithResponses(serverURL, func(c *v1.Client) error {
+		c.RequestEditors = []v1.RequestEditorFn{
+			v1.PhyAuthInterceptor(token, secret),
+			v1.PhyRequestInterceptor(),
 		}
 		return nil
 	})
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 
-	servers, err := client.ListServersWithResponse(context.Background(), &ListServersParams{})
+	services, err := client.ListServicesWithResponse(context.Background(), &v1.ListServicesParams{})
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 
-	t.Log(string(servers.Body))
+	fmt.Println(services.JSON200.Services[0].Nickname)
+	// output:
+	// server01
 }

--- a/example_fake_test.go
+++ b/example_fake_test.go
@@ -23,10 +23,13 @@ import (
 	"github.com/sacloud/phy-go/fake/server"
 )
 
-func initFakeServer() func() {
+func init() {
+	initFakeServer()
+}
+
+func initFakeServer() {
 	sv := httptest.NewServer(fakeServer.Handler())
 	serverURL = sv.URL
-	return sv.Close
 }
 
 var fakeServer = &server.Server{

--- a/example_test.go
+++ b/example_test.go
@@ -26,9 +26,6 @@ import (
 var serverURL = phy.DefaultAPIRootURL
 
 func Example() {
-	// Fakeサーバの初期化(本番環境で利用する場合この処理は不要)
-	defer initFakeServer()()
-
 	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
 	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
 
@@ -53,9 +50,6 @@ func Example() {
 }
 
 func ExampleServerAPI() {
-	// Fakeサーバの初期化(本番環境で利用する場合この処理は不要)
-	defer initFakeServer()()
-
 	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
 	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
 
@@ -89,9 +83,6 @@ func ExampleServerAPI() {
 }
 
 func ExampleServiceAPI() {
-	// Fakeサーバの初期化(本番環境で利用する場合この処理は不要)
-	defer initFakeServer()()
-
 	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
 	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
 


### PR DESCRIPTION
- Move fake server related codes into init()
- Added examples for v1 package

メモ: ドキュメント上、Example()の中にFakeサーバ関連コードがあるのは好ましくないため、別ファイルに`init()`を設けてそちらにFakeサーバ初期化コードを移動。Fakeサーバの終了処理を適切に行なっていないが今回は問題ないと思われる。