### PR TITLE
sacloud/api-client-goの導入

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,15 +15,12 @@
 package phy
 
 import (
-	"context"
 	"fmt"
-	"net/http"
 	"runtime"
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/go-retryablehttp"
-	sacloudhttp "github.com/sacloud/go-http"
+	client "github.com/sacloud/api-client-go"
 	v1 "github.com/sacloud/phy-go/apis/v1"
 )
 
@@ -36,34 +33,35 @@ var UserAgent = fmt.Sprintf(
 	Version,
 	runtime.GOOS,
 	runtime.GOARCH,
-	sacloudhttp.DefaultUserAgent,
+	client.DefaultUserAgent,
 )
 
 // Client APIクライアント
 type Client struct {
-	// Token APIキー: トークン
-	Token string
-	// Token APIキー: シークレット
-	Secret string
-
-	// AcceptLanguage APIリクエスト時のAccept-Languageヘッダーの値
-	AcceptLanguage string
-
-	// Gzip APIリクエストでgzipを有効にするかのフラグ
-	Gzip bool
+	// Profile usacloud互換プロファイル名
+	Profile string
 
 	// APIRootURL APIのリクエスト先URLプレフィックス、省略可能
 	APIRootURL string
 
-	// Trace トレースログ出力フラグ
-	Trace bool
+	// AccessToken APIキー:トークン
+	// Optionsでの指定より優先される
+	AccessToken string
+	// AccessTokenSecret APIキー:シークレット
+	// Optionsでの指定より優先される
+	AccessTokenSecret string
 
-	// HTTPClient APIリクエストで使用されるHTTPクライアント
-	//
-	// 省略した場合はhttp.DefaultClientが使用される
-	HTTPClient *http.Client
+	// Options HTTPクライアント関連オプション
+	Options *client.Options
+
+	// DisableProfile usacloud互換プロファイルからの設定読み取りを無効化
+	DisableProfile bool
+
+	// DisableEnv 環境変数からの設定読み取りを無効化
+	DisableEnv bool
 
 	initOnce sync.Once
+	factory  *client.Factory
 }
 
 func (c *Client) serverURL() string {
@@ -77,47 +75,55 @@ func (c *Client) serverURL() string {
 	return v
 }
 
-func (c *Client) httpClient() *http.Client {
-	client := http.DefaultClient
-	if c.HTTPClient != nil {
-		client = c.HTTPClient
-	}
-
+func (c *Client) init() error {
+	var initError error
 	c.initOnce.Do(func() {
-		if c.Trace {
-			client.Transport = &sacloudhttp.TracingRoundTripper{
-				Transport: client.Transport,
+		var opts []*client.Options
+		// 1: Profile
+		if !c.DisableProfile {
+			o, err := client.OptionsFromProfile(c.Profile)
+			if err != nil {
+				initError = err
+				return
 			}
+			opts = append(opts, o)
 		}
+
+		// 2: Env
+		if !c.DisableEnv {
+			opts = append(opts, client.OptionsFromEnv())
+		}
+
+		// 3: UserAgent
+		opts = append(opts, &client.Options{
+			UserAgent: UserAgent,
+		})
+
+		// 4: Options
+		if c.Options != nil {
+			opts = append(opts, c.Options)
+		}
+
+		// 5: フィールドのAPIキー
+		opts = append(opts, &client.Options{
+			AccessToken:       c.AccessToken,
+			AccessTokenSecret: c.AccessTokenSecret,
+		})
+
+		c.factory = client.NewFactory(opts...)
 	})
-	return client
+	return initError
 }
 
-func (c *Client) apiClient() *v1.ClientWithResponses {
-	httpClient := &sacloudhttp.Client{
-		AccessToken:       c.Token,
-		AccessTokenSecret: c.Secret,
-		UserAgent:         UserAgent,
-		AcceptLanguage:    c.AcceptLanguage,
-		Gzip:              c.Gzip,
-		CheckRetryFunc: func(ctx context.Context, resp *http.Response, err error) (bool, error) {
-			if ctx.Err() != nil {
-				return false, ctx.Err()
-			}
-			if err != nil {
-				return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
-			}
-			if resp.StatusCode == 0 { // ステータスコードに応じてリトライしたい場合はここで対応
-				return true, nil
-			}
-			return false, nil
-		},
-		HTTPClient: c.httpClient(),
+func (c *Client) apiClient() (*v1.ClientWithResponses, error) {
+	if err := c.init(); err != nil {
+		return nil, err
 	}
+
 	return &v1.ClientWithResponses{
 		ClientInterface: &v1.Client{
 			Server: c.serverURL(),
-			Client: httpClient,
+			Client: c.factory.NewHttpRequestDoer(),
 		},
-	}
+	}, nil
 }

--- a/dedicated_subnets.go
+++ b/dedicated_subnets.go
@@ -35,7 +35,11 @@ func NewDedicatedSubnetOp(client *Client) DedicatedSubnetAPI {
 }
 
 func (op *DedicatedSubnetOp) List(ctx context.Context, params *v1.ListDedicatedSubnetsParams) (*v1.DedicatedSubnets, error) {
-	response, err := op.client.apiClient().ListDedicatedSubnetsWithResponse(ctx, params)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := apiClient.ListDedicatedSubnetsWithResponse(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -43,8 +47,13 @@ func (op *DedicatedSubnetOp) List(ctx context.Context, params *v1.ListDedicatedS
 }
 
 func (op *DedicatedSubnetOp) Read(ctx context.Context, dedicatedSubnetId v1.DedicatedSubnetId, refresh bool) (*v1.DedicatedSubnet, error) {
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+
 	params := &v1.ReadDedicatedSubnetParams{Refresh: &refresh}
-	response, err := op.client.apiClient().ReadDedicatedSubnetWithResponse(ctx, dedicatedSubnetId, params)
+	response, err := apiClient.ReadDedicatedSubnetWithResponse(ctx, dedicatedSubnetId, params)
 	if err != nil {
 		return nil, err
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -17,7 +17,6 @@ package phy_test
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/sacloud/phy-go"
 	v1 "github.com/sacloud/phy-go/apis/v1"
@@ -26,12 +25,7 @@ import (
 var serverURL = phy.DefaultAPIRootURL
 
 func Example() {
-	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
-	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
-
 	client := &phy.Client{
-		Token:      token,
-		Secret:     secret,
 		APIRootURL: serverURL, // 省略可
 	}
 
@@ -50,12 +44,7 @@ func Example() {
 }
 
 func ExampleServerAPI() {
-	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
-	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
-
 	client := &phy.Client{
-		Token:      token,
-		Secret:     secret,
 		APIRootURL: serverURL, // 省略可
 	}
 
@@ -83,12 +72,7 @@ func ExampleServerAPI() {
 }
 
 func ExampleServiceAPI() {
-	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
-	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
-
 	client := &phy.Client{
-		Token:      token,
-		Secret:     secret,
 		APIRootURL: serverURL, // 省略可
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,7 @@ require (
 	github.com/deepmap/oapi-codegen v1.9.0
 	github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a
 	github.com/gin-gonic/gin v1.7.4
-	github.com/hashicorp/go-retryablehttp v0.7.0
-	github.com/sacloud/go-http v0.0.3
+	github.com/sacloud/api-client-go v0.0.1
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,12 @@ github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUA
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/sacloud/go-http v0.0.3 h1:D0RDrPZnsvZ0coNWQYEVJfy/ar5/Pb3vMuV8pUxSC3E=
-github.com/sacloud/go-http v0.0.3/go.mod h1:OoIrSShwQSYT9p0AdnJ6hZ3rlhLf8tDvg5DjIu5YjxI=
+github.com/sacloud/api-client-go v0.0.1 h1:adcDKnqTfg9FijU/lCygv3uniRlSFSfSkAK+LK7g1uk=
+github.com/sacloud/api-client-go v0.0.1/go.mod h1:RvP4b31YdaVjXM/XQAvKAeTTs0vGdvfypvP/7ysWdAA=
+github.com/sacloud/go-http v0.0.4 h1:+vgx/uCctcGiHMe8jE+qirMKd3+d73MNZXK7nrUo0po=
+github.com/sacloud/go-http v0.0.4/go.mod h1:aYTXNuAnPmD6Ar3ktDaR1gPxJCPv2CqpppcYciy1hmo=
+github.com/sacloud/sacloud-go/pkg v0.0.0-20220310002004-ab494c9c1c6d h1:Rdj8QU3EZrmdUKJMvJ0U3kkgUZFLzZ5u1kMKdQnW7eY=
+github.com/sacloud/sacloud-go/pkg v0.0.0-20220310002004-ab494c9c1c6d/go.mod h1:/hcfG/jZlqNDRpnMDl9rm1aBLgNCeX1NF6FyaIwk9+k=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/phy_test.go
+++ b/phy_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	client "github.com/sacloud/api-client-go"
 	v1 "github.com/sacloud/phy-go/apis/v1"
 	"github.com/sacloud/phy-go/fake"
 	"github.com/sacloud/phy-go/fake/server"
@@ -76,13 +77,12 @@ func testClient(t *testing.T) *Client {
 	}
 
 	return &Client{
-		Token:          token,
-		Secret:         secret,
-		AcceptLanguage: "",
-		Gzip:           false,
-		Trace:          os.Getenv("SAKURACLOUD_TRACE") != "",
-		APIRootURL:     testServerURL,
-		HTTPClient:     testHTTPClient,
+		APIRootURL: testServerURL,
+		Options: &client.Options{
+			AccessToken:       token,
+			AccessTokenSecret: secret,
+			HttpClient:        testHTTPClient,
+		},
 	}
 }
 

--- a/private_networks.go
+++ b/private_networks.go
@@ -35,7 +35,11 @@ func NewPrivateNetworkOp(client *Client) PrivateNetworkAPI {
 }
 
 func (op *PrivateNetworkOp) List(ctx context.Context, params *v1.ListPrivateNetworksParams) (*v1.PrivateNetworks, error) {
-	response, err := op.client.apiClient().ListPrivateNetworksWithResponse(ctx, params)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := apiClient.ListPrivateNetworksWithResponse(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +47,11 @@ func (op *PrivateNetworkOp) List(ctx context.Context, params *v1.ListPrivateNetw
 }
 
 func (op *PrivateNetworkOp) Read(ctx context.Context, privateNetworkId v1.PrivateNetworkId) (*v1.PrivateNetwork, error) {
-	response, err := op.client.apiClient().ReadPrivateNetworkWithResponse(ctx, privateNetworkId)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := apiClient.ReadPrivateNetworkWithResponse(ctx, privateNetworkId)
 	if err != nil {
 		return nil, err
 	}

--- a/servers.go
+++ b/servers.go
@@ -46,7 +46,11 @@ func NewServerOp(client *Client) ServerAPI {
 }
 
 func (op *ServerOp) List(ctx context.Context, params *v1.ListServersParams) (*v1.Servers, error) {
-	response, err := op.client.apiClient().ListServersWithResponse(ctx, params)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := apiClient.ListServersWithResponse(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +58,11 @@ func (op *ServerOp) List(ctx context.Context, params *v1.ListServersParams) (*v1
 }
 
 func (op *ServerOp) Read(ctx context.Context, serverId v1.ServerId) (*v1.Server, error) {
-	response, err := op.client.apiClient().ReadServerWithResponse(ctx, serverId)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := apiClient.ReadServerWithResponse(ctx, serverId)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +74,11 @@ func (op *ServerOp) Read(ctx context.Context, serverId v1.ServerId) (*v1.Server,
 }
 
 func (op *ServerOp) ListOSImages(ctx context.Context, serverId v1.ServerId) ([]*v1.OsImage, error) {
-	response, err := op.client.apiClient().ListOSImagesWithResponse(ctx, serverId)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := apiClient.ListOSImagesWithResponse(ctx, serverId)
 	if err != nil {
 		return nil, err
 	}
@@ -83,15 +95,23 @@ func (op *ServerOp) ListOSImages(ctx context.Context, serverId v1.ServerId) ([]*
 }
 
 func (op *ServerOp) OSInstall(ctx context.Context, serverId v1.ServerId, params v1.OsInstallParameter) error {
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return err
+	}
 	headers := &v1.OSInstallParams{
 		XRequestedWith: v1.OSInstallParamsXRequestedWith(v1.XMLHttpRequest),
 	}
-	_, err := op.client.apiClient().OSInstall(ctx, serverId, headers, v1.OSInstallJSONRequestBody(params))
+	_, err = apiClient.OSInstall(ctx, serverId, headers, v1.OSInstallJSONRequestBody(params))
 	return err
 }
 
 func (op *ServerOp) ReadPortChannel(ctx context.Context, serverId v1.ServerId, portChannelId v1.PortChannelId) (*v1.PortChannel, error) {
-	response, err := op.client.apiClient().ReadServerPortChannelWithResponse(ctx, serverId, portChannelId)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := apiClient.ReadServerPortChannelWithResponse(ctx, serverId, portChannelId)
 	if err != nil {
 		return nil, err
 	}
@@ -103,10 +123,14 @@ func (op *ServerOp) ReadPortChannel(ctx context.Context, serverId v1.ServerId, p
 }
 
 func (op *ServerOp) ConfigureBonding(ctx context.Context, serverId v1.ServerId, portChannelId v1.PortChannelId, params v1.ConfigureBondingParameter) (*v1.PortChannel, error) {
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
 	headers := &v1.ServerConfigureBondingParams{
 		XRequestedWith: v1.ServerConfigureBondingParamsXRequestedWith(v1.XMLHttpRequest),
 	}
-	response, err := op.client.apiClient().ServerConfigureBondingWithResponse(ctx, serverId, portChannelId, headers, v1.ServerConfigureBondingJSONRequestBody(params))
+	response, err := apiClient.ServerConfigureBondingWithResponse(ctx, serverId, portChannelId, headers, v1.ServerConfigureBondingJSONRequestBody(params))
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +143,11 @@ func (op *ServerOp) ConfigureBonding(ctx context.Context, serverId v1.ServerId, 
 }
 
 func (op *ServerOp) ReadPort(ctx context.Context, serverId v1.ServerId, portId v1.PortId) (*v1.InterfacePort, error) {
-	response, err := op.client.apiClient().ReadServerPortWithResponse(ctx, serverId, portId)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := apiClient.ReadServerPortWithResponse(ctx, serverId, portId)
 	if err != nil {
 		return nil, err
 	}
@@ -131,10 +159,14 @@ func (op *ServerOp) ReadPort(ctx context.Context, serverId v1.ServerId, portId v
 }
 
 func (op *ServerOp) UpdatePort(ctx context.Context, serverId v1.ServerId, portId v1.PortId, params v1.UpdateServerPortParameter) (*v1.InterfacePort, error) {
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
 	headers := &v1.UpdateServerPortParams{
 		XRequestedWith: v1.UpdateServerPortParamsXRequestedWith(v1.XMLHttpRequest),
 	}
-	response, err := op.client.apiClient().UpdateServerPortWithResponse(ctx, serverId, portId, headers, v1.UpdateServerPortJSONRequestBody(params))
+	response, err := apiClient.UpdateServerPortWithResponse(ctx, serverId, portId, headers, v1.UpdateServerPortJSONRequestBody(params))
 	if err != nil {
 		return nil, err
 	}
@@ -147,10 +179,14 @@ func (op *ServerOp) UpdatePort(ctx context.Context, serverId v1.ServerId, portId
 }
 
 func (op *ServerOp) EnablePort(ctx context.Context, serverId v1.ServerId, portId v1.PortId, enable bool) (*v1.InterfacePort, error) {
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
 	headers := &v1.EnableServerPortParams{
 		XRequestedWith: v1.EnableServerPortParamsXRequestedWith(v1.XMLHttpRequest),
 	}
-	response, err := op.client.apiClient().EnableServerPortWithResponse(ctx, serverId, portId, headers, v1.EnableServerPortJSONRequestBody{Enable: enable})
+	response, err := apiClient.EnableServerPortWithResponse(ctx, serverId, portId, headers, v1.EnableServerPortJSONRequestBody{Enable: enable})
 	if err != nil {
 		return nil, err
 	}
@@ -163,10 +199,14 @@ func (op *ServerOp) EnablePort(ctx context.Context, serverId v1.ServerId, portId
 }
 
 func (op *ServerOp) AssignNetwork(ctx context.Context, serverId v1.ServerId, portId v1.PortId, params v1.AssignNetworkParameter) (*v1.InterfacePort, error) {
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
 	headers := &v1.ServerAssignNetworkParams{
 		XRequestedWith: v1.ServerAssignNetworkParamsXRequestedWith(v1.XMLHttpRequest),
 	}
-	response, err := op.client.apiClient().ServerAssignNetworkWithResponse(ctx, serverId, portId, headers, v1.ServerAssignNetworkJSONRequestBody(params))
+	response, err := apiClient.ServerAssignNetworkWithResponse(ctx, serverId, portId, headers, v1.ServerAssignNetworkJSONRequestBody(params))
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +219,11 @@ func (op *ServerOp) AssignNetwork(ctx context.Context, serverId v1.ServerId, por
 }
 
 func (op *ServerOp) ReadTrafficByPort(ctx context.Context, serverId v1.ServerId, portId v1.PortId, params v1.ReadServerTrafficByPortParams) (*v1.TrafficGraph, error) {
-	response, err := op.client.apiClient().ReadServerTrafficByPortWithResponse(ctx, serverId, portId, &params)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := apiClient.ReadServerTrafficByPortWithResponse(ctx, serverId, portId, &params)
 	if err != nil {
 		return nil, err
 	}
@@ -191,15 +235,23 @@ func (op *ServerOp) ReadTrafficByPort(ctx context.Context, serverId v1.ServerId,
 }
 
 func (op *ServerOp) PowerControl(ctx context.Context, serverId v1.ServerId, operation v1.ServerPowerOperations) error {
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return err
+	}
 	headers := &v1.ServerPowerControlParams{
 		XRequestedWith: v1.ServerPowerControlParamsXRequestedWith(v1.XMLHttpRequest),
 	}
-	_, err := op.client.apiClient().ServerPowerControl(ctx, serverId, headers, v1.ServerPowerControlJSONRequestBody{Operation: operation})
+	_, err = apiClient.ServerPowerControl(ctx, serverId, headers, v1.ServerPowerControlJSONRequestBody{Operation: operation})
 	return err
 }
 
 func (op *ServerOp) ReadPowerStatus(ctx context.Context, serverId v1.ServerId) (*v1.ServerPowerStatus, error) {
-	response, err := op.client.apiClient().ReadServerPowerStatusWithResponse(ctx, serverId)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := apiClient.ReadServerPowerStatusWithResponse(ctx, serverId)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +263,11 @@ func (op *ServerOp) ReadPowerStatus(ctx context.Context, serverId v1.ServerId) (
 }
 
 func (op *ServerOp) ReadRAIDStatus(ctx context.Context, serverId v1.ServerId, refresh bool) (*v1.RaidStatus, error) {
-	response, err := op.client.apiClient().ReadRAIDStatusWithResponse(ctx, serverId, &v1.ReadRAIDStatusParams{Refresh: &refresh})
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := apiClient.ReadRAIDStatusWithResponse(ctx, serverId, &v1.ReadRAIDStatusParams{Refresh: &refresh})
 	if err != nil {
 		return nil, err
 	}

--- a/services.go
+++ b/services.go
@@ -37,7 +37,11 @@ func NewServiceOp(client *Client) ServiceAPI {
 }
 
 func (op *ServiceOp) List(ctx context.Context, params *v1.ListServicesParams) (*v1.Services, error) {
-	response, err := op.client.apiClient().ListServicesWithResponse(ctx, params)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := apiClient.ListServicesWithResponse(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +49,11 @@ func (op *ServiceOp) List(ctx context.Context, params *v1.ListServicesParams) (*
 }
 
 func (op *ServiceOp) Read(ctx context.Context, serviceId v1.ServiceId) (*v1.Service, error) {
-	response, err := op.client.apiClient().ReadServiceWithResponse(ctx, serviceId)
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := apiClient.ReadServiceWithResponse(ctx, serviceId)
 	if err != nil {
 		return nil, err
 	}
@@ -57,10 +65,14 @@ func (op *ServiceOp) Read(ctx context.Context, serviceId v1.ServiceId) (*v1.Serv
 }
 
 func (op *ServiceOp) Update(ctx context.Context, serviceId v1.ServiceId, params v1.UpdateServiceParameter) (*v1.Service, error) {
+	apiClient, err := op.client.apiClient()
+	if err != nil {
+		return nil, err
+	}
 	headers := &v1.UpdateServiceParams{
 		XRequestedWith: v1.UpdateServiceParamsXRequestedWith(v1.XMLHttpRequest),
 	}
-	response, err := op.client.apiClient().UpdateServiceWithResponse(ctx, serviceId, headers, v1.UpdateServiceJSONRequestBody(params))
+	response, err := apiClient.UpdateServiceWithResponse(ctx, serviceId, headers, v1.UpdateServiceJSONRequestBody(params))
 	if err != nil {
 		return nil, err
 	}

--- a/version.go
+++ b/version.go
@@ -17,6 +17,6 @@ package phy
 var (
 	// Version app version
 	Version = "v0.0.2"
-	// Revision git commit short commithash
+	// Revision git commit short commit hash
 	Revision = "xxxxxx" // set on build time
 )


### PR DESCRIPTION
sacloud/api-client-goを導入する。

これにより各種環境変数(SAKURACLOUD_xxx)やUsacloud互換のプロファイル機能が利用可能になる。
オプションでこれらを無効にすることも可能。

```go
// 特にオプションを指定しなかった場合は環境変数+プロファイルが利用される
apiClient := &phy.Client{}
```

```go
// 環境変数+プロファイルからの読み込みを無効にする場合(別途APIキーの指定が必要)
apiClient := &phy.Client{
	DisableProfile: true,
	DisableEnv:     true,

	AccessToken:       "xxx",
	AccessTokenSecret: "xxx",
}
```
