### PR TITLE
Fakeエンジンのフィールド公開用funcを追加

### DIFF
--- a/dedicated_subnets_test.go
+++ b/dedicated_subnets_test.go
@@ -25,6 +25,7 @@ import (
 func TestDedicatedSubnetOp_List(t *testing.T) {
 	onlyUnitTest(t)
 
+	subnets := testServer.Engine.GetDedicatedSubnets()
 	tests := []struct {
 		name    string
 		params  *v1.ListDedicatedSubnetsParams
@@ -36,10 +37,10 @@ func TestDedicatedSubnetOp_List(t *testing.T) {
 			params: &v1.ListDedicatedSubnetsParams{},
 			want: &v1.DedicatedSubnets{
 				Meta: v1.PaginateMeta{
-					Count: len(testValueDedicatedSubnets),
+					Count: len(subnets),
 				},
 				DedicatedSubnets: []v1.DedicatedSubnet{
-					*testValueDedicatedSubnet01,
+					*subnets[0],
 				},
 			},
 			wantErr: false,
@@ -63,6 +64,7 @@ func TestDedicatedSubnetOp_List(t *testing.T) {
 func TestDedicatedSubnetOp_Read(t *testing.T) {
 	onlyUnitTest(t)
 
+	ds := testServer.Engine.GetDedicatedSubnets()[0]
 	type args struct {
 		dedicatedSubnetId v1.DedicatedSubnetId
 		refresh           bool
@@ -76,10 +78,10 @@ func TestDedicatedSubnetOp_Read(t *testing.T) {
 		{
 			name: "minimum",
 			args: args{
-				dedicatedSubnetId: v1.DedicatedSubnetId(testValueDedicatedSubnet01.DedicatedSubnetId),
+				dedicatedSubnetId: v1.DedicatedSubnetId(ds.DedicatedSubnetId),
 				refresh:           false,
 			},
-			want:    testValueDedicatedSubnet01,
+			want:    ds,
 			wantErr: false,
 		},
 	}

--- a/fake/engine.go
+++ b/fake/engine.go
@@ -25,7 +25,8 @@ const defaultActionInterval = 100 * time.Millisecond
 
 // Engine Fakeサーバであつかうダミーデータを表す
 //
-// Serverに渡した後はDataStore内のデータを外部から操作しないこと
+// Serverに渡した後は各フィールドを外部から操作しないこと
+// 各フィールドの値を参照したい場合はGetxxx()を用いること
 type Engine struct {
 	Services         []*v1.Service
 	Servers          []*Server
@@ -41,6 +42,27 @@ type Engine struct {
 	GeneratedID int
 
 	mu sync.RWMutex
+}
+
+func (engine *Engine) GetServices() []*v1.Service {
+	defer engine.rLock()()
+	return engine.Services
+}
+
+func (engine *Engine) GetServers() []*Server {
+	defer engine.rLock()()
+	return engine.Servers
+}
+
+func (engine *Engine) GetDedicatedSubnets() []*v1.DedicatedSubnet {
+	defer engine.rLock()()
+	return engine.DedicatedSubnets
+}
+
+func (engine *Engine) GetPrivateNetworks() []*v1.PrivateNetwork {
+	defer engine.rLock()()
+	return engine.PrivateNetworks
+
 }
 
 func (engine *Engine) lock() func() {

--- a/phy_test.go
+++ b/phy_test.go
@@ -86,214 +86,202 @@ func testClient(t *testing.T) *Client {
 	}
 }
 
+var raidOverallStatus = v1.RaidStatusOverallStatusOk
+
 var testServer = &server.Server{
 	Engine: &fake.Engine{
-		Servers:          testValueServers,
-		Services:         testValueServices,
-		DedicatedSubnets: testValueDedicatedSubnets,
-		PrivateNetworks:  testValuePrivateNetworks,
-	},
-}
-
-var (
-	testValueServices = []*v1.Service{
-		testValueService01,
-	}
-	testValueService01 = &v1.Service{
-		Activated:   time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-		Description: pointer.String("description01"),
-		Nickname:    "service01",
-		OptionPlans: nil,
-		Plan: &v1.ServicePlan{
-			Name:   "plan01",
-			PlanId: "maker-series-spec-region-01",
-		},
-		ProductCategory: v1.ServiceProductCategoryServer,
-		ServiceId:       "100000000001",
-		Tags: []v1.Tag{
+		Servers: []*fake.Server{
 			{
-				Color: pointer.String("tag1"),
-				Label: "label",
-				TagId: 1,
-			},
-		},
-	}
-	testValueDedicatedSubnets = []*v1.DedicatedSubnet{
-		testValueDedicatedSubnet01,
-	}
-	testValueDedicatedSubnet01 = &v1.DedicatedSubnet{
-		ConfigStatus:      v1.DedicatedSubnetConfigStatusOperational,
-		DedicatedSubnetId: "2000000000001",
-		Firewall:          nil,
-		Ipv4: v1.Ipv4{
-			BroadcastAddress: "192.0.2.239",
-			GatewayAddress:   "192.0.2.225",
-			NetworkAddress:   "192.0.2.224",
-			PrefixLength:     28,
-		},
-		Ipv6: v1.Ipv6{
-			Enabled: false,
-		},
-		LoadBalancer: nil,
-		ServerCount:  1,
-		Service: v1.ServiceQuiet{
-			Activated:   time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-			Description: pointer.String("description01"),
-			Nickname:    "dedicated_subnet01",
-			ServiceId:   "200000000001",
-			Tags: &[]v1.Tag{
-				{
-					Color: pointer.String("tag1"),
-					Label: "label",
-					TagId: 1,
-				},
-			},
-		},
-		Zone: v1.Zone{
-			Region: "石狩",
-			ZoneId: 301,
-		},
-	}
-
-	testValuePrivateNetworks = []*v1.PrivateNetwork{
-		testValuePrivateNetwork01,
-	}
-	testValuePrivateNetwork01 = &v1.PrivateNetwork{
-		PrivateNetworkId: "300000000001",
-		ServerCount:      1,
-		Service: v1.ServiceQuiet{
-			Activated: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-			Nickname:  "private-network01",
-			ServiceId: "300000000001",
-		},
-		VlanId: 1,
-		Zone: v1.Zone{
-			Region: "is",
-			ZoneId: 302,
-		},
-	}
-
-	testValueServers = []*fake.Server{
-		testValueServer01,
-	}
-	testValueServer01 = &fake.Server{
-		Server: &v1.Server{
-			CachedPowerStatus: &v1.CachedPowerStatus{
-				Status: v1.CachedPowerStatusStatusOn,
-				Stored: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-			},
-			Ipv4: &v1.ServerIpv4Global{
-				GatewayAddress: "192.0.2.1",
-				IpAddress:      "192.0.2.11",
-				NameServers:    []string{"198.51.100.1", "198.51.100.2"},
-				NetworkAddress: "192.0.2.0",
-				PrefixLength:   24,
-				Type:           v1.ServerIpv4GlobalTypeCommonIpAddress,
-			},
-			LockStatus: nil,
-			PortChannels: []v1.PortChannel{
-				{
-					BondingType:   v1.BondingTypeLacp,
-					LinkSpeedType: v1.PortChannelLinkSpeedTypeN1gbe,
-					Locked:        false,
-					PortChannelId: 1001,
-					Ports:         []int{2001},
-				},
-			},
-			Ports: []v1.InterfacePort{
-				{
-					Enabled:             true,
-					GlobalBandwidthMbps: nil,
-					Internet:            nil,
-					LocalBandwidthMbps:  nil,
-					Mode:                nil,
-					Nickname:            "server01-port01",
-					PortChannelId:       1001,
-					PortId:              2001,
-					PrivateNetworks:     nil,
-				},
-			},
-			ServerId: "400000000001",
-			Service: v1.ServiceQuiet{
-				Activated:   time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-				Description: nil,
-				Nickname:    "server01",
-				ServiceId:   "400000000001",
-				Tags:        nil,
-			},
-			Spec: v1.ServerSpec{
-				CpuClockSpeed:         3,
-				CpuCoreCount:          4,
-				CpuCount:              1,
-				CpuModelName:          "E3-1220 v6",
-				MemorySize:            8,
-				PortChannel10gbeCount: 0,
-				PortChannel1gbeCount:  1,
-				Storages: []v1.Storage{
-					{
-						BusType:     v1.StorageBusTypeSata,
-						DeviceCount: 2,
-						MediaType:   v1.StorageMediaTypeSsd,
-						Size:        1000,
+				Server: &v1.Server{
+					CachedPowerStatus: &v1.CachedPowerStatus{
+						Status: v1.CachedPowerStatusStatusOn,
+						Stored: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+					},
+					Ipv4: &v1.ServerIpv4Global{
+						GatewayAddress: "192.0.2.1",
+						IpAddress:      "192.0.2.11",
+						NameServers:    []string{"198.51.100.1", "198.51.100.2"},
+						NetworkAddress: "192.0.2.0",
+						PrefixLength:   24,
+						Type:           v1.ServerIpv4GlobalTypeCommonIpAddress,
+					},
+					LockStatus: nil,
+					PortChannels: []v1.PortChannel{
+						{
+							BondingType:   v1.BondingTypeLacp,
+							LinkSpeedType: v1.PortChannelLinkSpeedTypeN1gbe,
+							Locked:        false,
+							PortChannelId: 1001,
+							Ports:         []int{2001},
+						},
+					},
+					Ports: []v1.InterfacePort{
+						{
+							Enabled:             true,
+							GlobalBandwidthMbps: nil,
+							Internet:            nil,
+							LocalBandwidthMbps:  nil,
+							Mode:                nil,
+							Nickname:            "server01-port01",
+							PortChannelId:       1001,
+							PortId:              2001,
+							PrivateNetworks:     nil,
+						},
+					},
+					ServerId: "400000000001",
+					Service: v1.ServiceQuiet{
+						Activated:   time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+						Description: nil,
+						Nickname:    "server01",
+						ServiceId:   "400000000001",
+						Tags:        nil,
+					},
+					Spec: v1.ServerSpec{
+						CpuClockSpeed:         3,
+						CpuCoreCount:          4,
+						CpuCount:              1,
+						CpuModelName:          "E3-1220 v6",
+						MemorySize:            8,
+						PortChannel10gbeCount: 0,
+						PortChannel1gbeCount:  1,
+						Storages: []v1.Storage{
+							{
+								BusType:     v1.StorageBusTypeSata,
+								DeviceCount: 2,
+								MediaType:   v1.StorageMediaTypeSsd,
+								Size:        1000,
+							},
+						},
+						TotalStorageDeviceCount: 1,
+					},
+					Zone: v1.Zone{
+						Region: "is",
+						ZoneId: 302,
 					},
 				},
-				TotalStorageDeviceCount: 1,
-			},
-			Zone: v1.Zone{
-				Region: "is",
-				ZoneId: 302,
+				RaidStatus: &v1.RaidStatus{
+					LogicalVolumes: []v1.RaidLogicalVolume{
+						{
+							PhysicalDeviceIds: []string{"0", "1"},
+							RaidLevel:         "1",
+							Status:            v1.RaidLogicalVolumeStatusOk,
+							VolumeId:          "0",
+						},
+					},
+					Monitored:     time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+					OverallStatus: &raidOverallStatus,
+					PhysicalDevices: []v1.RaidPhysicalDevice{
+						{
+							DeviceId: "0",
+							Slot:     0,
+							Status:   v1.RaidPhysicalDeviceStatusOk,
+						},
+						{
+							DeviceId: "1",
+							Slot:     1,
+							Status:   v1.RaidPhysicalDeviceStatusOk,
+						},
+					},
+				},
+				OSImages: []*v1.OsImage{
+					{
+						ManualPartition: true,
+						Name:            "Usacloud Linux",
+						OsImageId:       "usacloud",
+						RequirePassword: true,
+						SuperuserName:   "root",
+					},
+				},
+				PowerStatus: &v1.ServerPowerStatus{
+					Status: v1.ServerPowerStatusStatusOn,
+				},
+				TrafficGraph: &v1.TrafficGraph{
+					Receive: []v1.TrafficGraphData{
+						{
+							Timestamp: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+							Value:     1,
+						},
+					},
+					Transmit: []v1.TrafficGraphData{
+						{
+							Timestamp: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+							Value:     1,
+						},
+					},
+				},
 			},
 		},
-		RaidStatus: &v1.RaidStatus{
-			LogicalVolumes: []v1.RaidLogicalVolume{
-				{
-					PhysicalDeviceIds: []string{"0", "1"},
-					RaidLevel:         "1",
-					Status:            v1.RaidLogicalVolumeStatusOk,
-					VolumeId:          "0",
-				},
-			},
-			Monitored:     time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-			OverallStatus: &raidOverallStatus,
-			PhysicalDevices: []v1.RaidPhysicalDevice{
-				{
-					DeviceId: "0",
-					Slot:     0,
-					Status:   v1.RaidPhysicalDeviceStatusOk,
-				},
-				{
-					DeviceId: "1",
-					Slot:     1,
-					Status:   v1.RaidPhysicalDeviceStatusOk,
-				},
-			},
-		},
-		OSImages: []*v1.OsImage{
+		Services: []*v1.Service{
 			{
-				ManualPartition: true,
-				Name:            "Usacloud Linux",
-				OsImageId:       "usacloud",
-				RequirePassword: true,
-				SuperuserName:   "root",
-			},
-		},
-		PowerStatus: &v1.ServerPowerStatus{
-			Status: v1.ServerPowerStatusStatusOn,
-		},
-		TrafficGraph: &v1.TrafficGraph{
-			Receive: []v1.TrafficGraphData{
-				{
-					Timestamp: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					Value:     1,
+				Activated:   time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+				Description: pointer.String("description01"),
+				Nickname:    "service01",
+				OptionPlans: nil,
+				Plan: &v1.ServicePlan{
+					Name:   "plan01",
+					PlanId: "maker-series-spec-region-01",
 				},
-			},
-			Transmit: []v1.TrafficGraphData{
-				{
-					Timestamp: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
-					Value:     1,
+				ProductCategory: v1.ServiceProductCategoryServer,
+				ServiceId:       "100000000001",
+				Tags: []v1.Tag{
+					{
+						Color: pointer.String("tag1"),
+						Label: "label",
+						TagId: 1,
+					},
 				},
 			},
 		},
-	}
-	raidOverallStatus = v1.RaidStatusOverallStatusOk
-)
+		DedicatedSubnets: []*v1.DedicatedSubnet{
+			{
+				ConfigStatus:      v1.DedicatedSubnetConfigStatusOperational,
+				DedicatedSubnetId: "2000000000001",
+				Firewall:          nil,
+				Ipv4: v1.Ipv4{
+					BroadcastAddress: "192.0.2.239",
+					GatewayAddress:   "192.0.2.225",
+					NetworkAddress:   "192.0.2.224",
+					PrefixLength:     28,
+				},
+				Ipv6: v1.Ipv6{
+					Enabled: false,
+				},
+				LoadBalancer: nil,
+				ServerCount:  1,
+				Service: v1.ServiceQuiet{
+					Activated:   time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+					Description: pointer.String("description01"),
+					Nickname:    "dedicated_subnet01",
+					ServiceId:   "200000000001",
+					Tags: &[]v1.Tag{
+						{
+							Color: pointer.String("tag1"),
+							Label: "label",
+							TagId: 1,
+						},
+					},
+				},
+				Zone: v1.Zone{
+					Region: "石狩",
+					ZoneId: 301,
+				},
+			},
+		},
+		PrivateNetworks: []*v1.PrivateNetwork{
+			{
+				PrivateNetworkId: "300000000001",
+				ServerCount:      1,
+				Service: v1.ServiceQuiet{
+					Activated: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+					Nickname:  "private-network01",
+					ServiceId: "300000000001",
+				},
+				VlanId: 1,
+				Zone: v1.Zone{
+					Region: "is",
+					ZoneId: 302,
+				},
+			},
+		},
+	},
+}

--- a/private_networks_test.go
+++ b/private_networks_test.go
@@ -24,6 +24,7 @@ import (
 
 func TestPrivateNetworkOp_List(t *testing.T) {
 	onlyUnitTest(t)
+	networks := testServer.Engine.GetPrivateNetworks()
 
 	tests := []struct {
 		name    string
@@ -36,10 +37,10 @@ func TestPrivateNetworkOp_List(t *testing.T) {
 			params: &v1.ListPrivateNetworksParams{},
 			want: &v1.PrivateNetworks{
 				Meta: v1.PaginateMeta{
-					Count: len(testValuePrivateNetworks),
+					Count: len(networks),
 				},
 				PrivateNetworks: []v1.PrivateNetwork{
-					*testValuePrivateNetwork01,
+					*networks[0],
 				},
 			},
 			wantErr: false,
@@ -62,6 +63,7 @@ func TestPrivateNetworkOp_List(t *testing.T) {
 
 func TestPrivateNetworkOp_Read(t *testing.T) {
 	onlyUnitTest(t)
+	networks := testServer.Engine.GetPrivateNetworks()
 
 	tests := []struct {
 		name             string
@@ -71,8 +73,8 @@ func TestPrivateNetworkOp_Read(t *testing.T) {
 	}{
 		{
 			name:             "minimum",
-			privateNetworkId: v1.PrivateNetworkId(testValuePrivateNetwork01.PrivateNetworkId),
-			want:             testValuePrivateNetwork01,
+			privateNetworkId: v1.PrivateNetworkId(networks[0].PrivateNetworkId),
+			want:             networks[0],
 			wantErr:          false,
 		},
 	}

--- a/servers_test.go
+++ b/servers_test.go
@@ -25,6 +25,7 @@ import (
 
 func TestServerOp_List(t *testing.T) {
 	onlyUnitTest(t)
+	servers := testServer.Engine.GetServers()
 
 	tests := []struct {
 		name    string
@@ -40,7 +41,7 @@ func TestServerOp_List(t *testing.T) {
 					Count: 1,
 				},
 				Servers: []v1.Server{
-					*testValueServer01.Server,
+					*servers[0].Server,
 				},
 			},
 			wantErr: false,
@@ -63,6 +64,7 @@ func TestServerOp_List(t *testing.T) {
 
 func TestServerOp_Read(t *testing.T) {
 	onlyUnitTest(t)
+	servers := testServer.Engine.GetServers()
 
 	tests := []struct {
 		name     string
@@ -72,8 +74,8 @@ func TestServerOp_Read(t *testing.T) {
 	}{
 		{
 			name:     "minimum",
-			serverId: v1.ServerId(testValueServer01.Id()),
-			want:     testValueServer01.Server,
+			serverId: v1.ServerId(servers[0].Id()),
+			want:     servers[0].Server,
 			wantErr:  false,
 		},
 	}
@@ -94,6 +96,7 @@ func TestServerOp_Read(t *testing.T) {
 
 func TestServerOp_ListOSImages(t *testing.T) {
 	onlyUnitTest(t)
+	servers := testServer.Engine.GetServers()
 
 	tests := []struct {
 		name     string
@@ -103,8 +106,8 @@ func TestServerOp_ListOSImages(t *testing.T) {
 	}{
 		{
 			name:     "minimum",
-			serverId: v1.ServerId(testValueServer01.Id()),
-			want:     testValueServer01.OSImages,
+			serverId: v1.ServerId(servers[0].Id()),
+			want:     servers[0].OSImages,
 			wantErr:  false,
 		},
 	}
@@ -125,6 +128,7 @@ func TestServerOp_ListOSImages(t *testing.T) {
 
 func TestServerOp_OSInstall(t *testing.T) {
 	onlyUnitTest(t)
+	servers := testServer.Engine.GetServers()
 
 	type args struct {
 		serverId v1.ServerId
@@ -138,7 +142,7 @@ func TestServerOp_OSInstall(t *testing.T) {
 		{
 			name: "minimum",
 			args: args{
-				serverId: v1.ServerId(testValueServer01.Id()),
+				serverId: v1.ServerId(servers[0].Id()),
 				params: v1.OsInstallParameter{
 					ManualPartition: true,
 					OsImageId:       "usacloud",
@@ -162,6 +166,7 @@ func TestServerOp_OSInstall(t *testing.T) {
 
 func TestServerOp_ReadPortChannel(t *testing.T) {
 	onlyUnitTest(t)
+	servers := testServer.Engine.GetServers()
 
 	type args struct {
 		serverId      v1.ServerId
@@ -176,10 +181,10 @@ func TestServerOp_ReadPortChannel(t *testing.T) {
 		{
 			name: "minimum",
 			args: args{
-				serverId:      v1.ServerId(testValueServer01.Id()),
+				serverId:      v1.ServerId(servers[0].Id()),
 				portChannelId: 1001,
 			},
-			want:    &testValueServer01.Server.PortChannels[0],
+			want:    &servers[0].Server.PortChannels[0],
 			wantErr: false,
 		},
 	}
@@ -200,6 +205,7 @@ func TestServerOp_ReadPortChannel(t *testing.T) {
 
 func TestServerOp_ReadPort(t *testing.T) {
 	onlyUnitTest(t)
+	servers := testServer.Engine.GetServers()
 
 	type args struct {
 		serverId v1.ServerId
@@ -214,10 +220,10 @@ func TestServerOp_ReadPort(t *testing.T) {
 		{
 			name: "minimum",
 			args: args{
-				serverId: v1.ServerId(testValueServer01.Id()),
+				serverId: v1.ServerId(servers[0].Id()),
 				portId:   2001,
 			},
-			want:    &testValueServer01.Server.Ports[0],
+			want:    &servers[0].Server.Ports[0],
 			wantErr: false,
 		},
 	}
@@ -238,8 +244,9 @@ func TestServerOp_ReadPort(t *testing.T) {
 
 func TestServerOp_UpdatePort(t *testing.T) {
 	onlyUnitTest(t)
+	servers := testServer.Engine.GetServers()
 
-	port := testValueServer01.Server.Ports[0]
+	port := servers[0].Server.Ports[0]
 	type args struct {
 		serverId v1.ServerId
 		portId   v1.PortId
@@ -254,7 +261,7 @@ func TestServerOp_UpdatePort(t *testing.T) {
 		{
 			name: "minimum",
 			args: args{
-				serverId: v1.ServerId(testValueServer01.Id()),
+				serverId: v1.ServerId(servers[0].Id()),
 				portId:   2001,
 				params: v1.UpdateServerPortParameter{
 					Nickname: "server01-port01-upd",
@@ -291,10 +298,12 @@ func TestServerOp_UpdatePort(t *testing.T) {
 
 func TestServerOp_AssignNetwork(t *testing.T) {
 	onlyUnitTest(t)
+	servers := testServer.Engine.GetServers()
+	subnets := testServer.Engine.GetDedicatedSubnets()
 
 	var internetType = v1.AssignNetworkParameterInternetTypeDedicatedSubnet
 	var mode = v1.InterfacePortModeAccess
-	port := testValueServer01.Server.Ports[0]
+	port := servers[0].Server.Ports[0]
 
 	type args struct {
 		serverId v1.ServerId
@@ -310,10 +319,10 @@ func TestServerOp_AssignNetwork(t *testing.T) {
 		{
 			name: "minimum",
 			args: args{
-				serverId: v1.ServerId(testValueServer01.Id()),
+				serverId: v1.ServerId(servers[0].Id()),
 				portId:   v1.PortId(port.PortId),
 				params: v1.AssignNetworkParameter{
-					DedicatedSubnetId: pointer.String(testValueDedicatedSubnet01.DedicatedSubnetId),
+					DedicatedSubnetId: pointer.String(subnets[0].DedicatedSubnetId),
 					InternetType:      &internetType,
 					Mode:              v1.AssignNetworkParameterModeAccess,
 				},
@@ -323,11 +332,11 @@ func TestServerOp_AssignNetwork(t *testing.T) {
 				GlobalBandwidthMbps: pointer.Int(500),
 				Internet: &v1.Internet{
 					DedicatedSubnet: &v1.AttachedDedicatedSubnet{
-						DedicatedSubnetId: testValueDedicatedSubnet01.DedicatedSubnetId,
-						Nickname:          testValueDedicatedSubnet01.Service.Nickname,
+						DedicatedSubnetId: subnets[0].DedicatedSubnetId,
+						Nickname:          subnets[0].Service.Nickname,
 					},
-					NetworkAddress: testValueDedicatedSubnet01.Ipv4.NetworkAddress,
-					PrefixLength:   testValueDedicatedSubnet01.Ipv4.PrefixLength,
+					NetworkAddress: subnets[0].Ipv4.NetworkAddress,
+					PrefixLength:   subnets[0].Ipv4.PrefixLength,
 					SubnetType:     v1.InternetSubnetTypeDedicatedSubnet,
 				},
 				PrivateNetworks:    nil,
@@ -357,8 +366,9 @@ func TestServerOp_AssignNetwork(t *testing.T) {
 
 func TestServerOp_EnablePort(t *testing.T) {
 	onlyUnitTest(t)
+	servers := testServer.Engine.GetServers()
 
-	port := testValueServer01.Server.Ports[0]
+	port := servers[0].Server.Ports[0]
 	type args struct {
 		serverId v1.ServerId
 		portId   v1.PortId
@@ -373,7 +383,7 @@ func TestServerOp_EnablePort(t *testing.T) {
 		{
 			name: "minimum",
 			args: args{
-				serverId: v1.ServerId(testValueServer01.Id()),
+				serverId: v1.ServerId(servers[0].Id()),
 				portId:   v1.PortId(port.PortId),
 				enable:   false,
 			},
@@ -408,8 +418,9 @@ func TestServerOp_EnablePort(t *testing.T) {
 
 func TestServerOp_ReadTrafficByPort(t *testing.T) {
 	onlyUnitTest(t)
+	servers := testServer.Engine.GetServers()
 
-	port := testValueServer01.Server.Ports[0]
+	port := servers[0].Server.Ports[0]
 	type args struct {
 		serverId v1.ServerId
 		portId   v1.PortId
@@ -423,7 +434,7 @@ func TestServerOp_ReadTrafficByPort(t *testing.T) {
 		{
 			name: "minimum",
 			args: args{
-				serverId: v1.ServerId(testValueServer01.Id()),
+				serverId: v1.ServerId(servers[0].Id()),
 				portId:   v1.PortId(port.PortId),
 				params:   v1.ReadServerTrafficByPortParams{},
 			},
@@ -450,6 +461,7 @@ func TestServerOp_ReadTrafficByPort(t *testing.T) {
 
 func TestServerOp_PowerControl(t *testing.T) {
 	onlyUnitTest(t)
+	servers := testServer.Engine.GetServers()
 
 	type args struct {
 		serverId  v1.ServerId
@@ -463,7 +475,7 @@ func TestServerOp_PowerControl(t *testing.T) {
 		{
 			name: "minimum",
 			args: args{
-				serverId:  v1.ServerId(testValueServer01.Id()),
+				serverId:  v1.ServerId(servers[0].Id()),
 				operation: v1.ServerPowerOperationsReset,
 			},
 			wantErr: false,
@@ -483,6 +495,7 @@ func TestServerOp_PowerControl(t *testing.T) {
 
 func TestServerOp_ReadPowerStatus(t *testing.T) {
 	onlyUnitTest(t)
+	servers := testServer.Engine.GetServers()
 
 	tests := []struct {
 		name     string
@@ -492,8 +505,8 @@ func TestServerOp_ReadPowerStatus(t *testing.T) {
 	}{
 		{
 			name:     "minimum",
-			serverId: v1.ServerId(testValueServer01.Id()),
-			want:     testValueServer01.PowerStatus,
+			serverId: v1.ServerId(servers[0].Id()),
+			want:     servers[0].PowerStatus,
 			wantErr:  false,
 		},
 	}
@@ -514,6 +527,7 @@ func TestServerOp_ReadPowerStatus(t *testing.T) {
 
 func TestServerOp_ReadRAIDStatus(t *testing.T) {
 	onlyUnitTest(t)
+	servers := testServer.Engine.GetServers()
 
 	type args struct {
 		serverId v1.ServerId
@@ -528,10 +542,10 @@ func TestServerOp_ReadRAIDStatus(t *testing.T) {
 		{
 			name: "minimum",
 			args: args{
-				serverId: v1.ServerId(testValueServer01.Id()),
+				serverId: v1.ServerId(servers[0].Id()),
 				refresh:  false,
 			},
-			want:    testValueServer01.RaidStatus,
+			want:    servers[0].RaidStatus,
 			wantErr: false,
 		},
 	}
@@ -552,8 +566,8 @@ func TestServerOp_ReadRAIDStatus(t *testing.T) {
 
 func TestServerOp_ConfigureBonding(t *testing.T) {
 	onlyUnitTest(t)
-
-	portChannel := testValueServer01.Server.PortChannels[0]
+	servers := testServer.Engine.GetServers()
+	portChannel := servers[0].Server.PortChannels[0]
 
 	type args struct {
 		serverId      v1.ServerId
@@ -569,7 +583,7 @@ func TestServerOp_ConfigureBonding(t *testing.T) {
 		{
 			name: "minimum",
 			args: args{
-				serverId:      v1.ServerId(testValueServer01.Id()),
+				serverId:      v1.ServerId(servers[0].Id()),
 				portChannelId: v1.PortChannelId(portChannel.PortChannelId),
 				params: v1.ConfigureBondingParameter{
 					BondingType:   v1.BondingTypeLacp,

--- a/services_test.go
+++ b/services_test.go
@@ -30,6 +30,7 @@ import (
 
 func TestServiceOp_ListServices(t *testing.T) {
 	onlyUnitTest(t)
+	services := testServer.Engine.GetServices()
 
 	tests := []struct {
 		name    string
@@ -42,10 +43,10 @@ func TestServiceOp_ListServices(t *testing.T) {
 			args: &v1.ListServicesParams{},
 			want: &v1.Services{
 				Meta: v1.PaginateMeta{
-					Count: 1,
+					Count: len(services),
 				},
 				Services: []v1.Service{
-					*testValueService01,
+					*services[0],
 				},
 			},
 			wantErr: false,
@@ -68,6 +69,7 @@ func TestServiceOp_ListServices(t *testing.T) {
 
 func TestServiceOp_ReadService(t *testing.T) {
 	onlyUnitTest(t)
+	services := testServer.Engine.GetServices()
 
 	tests := []struct {
 		name      string
@@ -77,8 +79,8 @@ func TestServiceOp_ReadService(t *testing.T) {
 	}{
 		{
 			name:      "minimum",
-			serviceId: v1.ServiceId(testValueService01.ServiceId),
-			want:      testValueService01,
+			serviceId: v1.ServiceId(services[0].ServiceId),
+			want:      services[0],
 			wantErr:   false,
 		},
 	}
@@ -99,6 +101,7 @@ func TestServiceOp_ReadService(t *testing.T) {
 
 func TestServiceOp_UpdateService(t *testing.T) {
 	onlyUnitTest(t)
+	services := testServer.Engine.GetServices()
 
 	type args struct {
 		serviceId v1.ServiceId
@@ -113,7 +116,7 @@ func TestServiceOp_UpdateService(t *testing.T) {
 		{
 			name: "minimum",
 			args: args{
-				serviceId: v1.ServiceId(testValueService01.ServiceId),
+				serviceId: v1.ServiceId(services[0].ServiceId),
 				params: v1.UpdateServiceParameter{
 					Description: pointer.String("description01-upd"),
 					Nickname:    "service01-upd",


### PR DESCRIPTION
Fakeエンジンの各フィールドは初期化を容易にするためにエクスポートしているが、
Fakeサーバ起動後にそれらにアクセスするとエンジンのロックプロコトルを無視することになりDataRaceが発生しうる。
これを防ぐためにフィールド公開用funcを介して参照させるようにする。